### PR TITLE
Add HTTP proxy, watch mode, hostname support, and static linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ cmake_minimum_required(VERSION 3.20)
 project(proxinject)
 
 option(PROXINJECTEE_ONLY "only build proxyinjectee" OFF)
+option(CLI_ONLY "build CLI without GUI" OFF)
 
 if(NOT WIN32)
 	message(FATAL_ERROR "support Windows only")
@@ -26,6 +27,12 @@ endif()
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+
+# Static linking for MinGW to avoid runtime DLL dependencies
+if(MINGW)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc -static-libstdc++ -static")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -static-libgcc -static-libstdc++")
+endif()
 
 include(FetchContent)
 
@@ -102,6 +109,12 @@ target_compile_features(proxinjectee PUBLIC cxx_std_20)
 target_link_libraries(proxinjectee PUBLIC minhook ws2_32 protopuf proxinject_common)
 target_include_directories(proxinjectee PUBLIC ${asio_SOURCE_DIR}/asio/include)
 
+# Static link pthread for MinGW to avoid DLL dependency in injected DLL
+if(MINGW)
+    target_link_options(proxinjectee PRIVATE -static -static-libgcc -static-libstdc++)
+    target_link_libraries(proxinjectee PRIVATE C:/msys64/mingw64/lib/libwinpthread.a)
+endif()
+
 if(NOT PROXINJECTEE_ONLY)
 	file(GLOB INJECTOR_GUI_SRCS src/injector/injector_gui.cpp src/injector/ui_elements/*.cpp)
 
@@ -116,14 +129,14 @@ if(NOT PROXINJECTEE_ONLY)
 	include(ElementsConfigApp)
 
 	target_compile_features(proxinjector PUBLIC cxx_std_20)
-	target_link_libraries(proxinjector PUBLIC protopuf proxinject_common)
+	target_link_libraries(proxinjector PUBLIC protopuf proxinject_common mswsock)
 	target_include_directories(proxinjector PUBLIC ${asio_SOURCE_DIR}/asio/include)
 
 	file(GLOB INJECTOR_CLI_SRCS src/injector/injector_cli.cpp)
 
 	add_executable(proxinjector-cli ${INJECTOR_CLI_SRCS})
 	target_compile_features(proxinjector-cli PUBLIC cxx_std_20)
-	target_link_libraries(proxinjector-cli PUBLIC protopuf argparse spdlog proxinject_common)
+	target_link_libraries(proxinjector-cli PUBLIC protopuf argparse spdlog proxinject_common ws2_32 mswsock)
 	target_include_directories(proxinjector-cli PUBLIC ${asio_SOURCE_DIR}/asio/include)
 endif()
 

--- a/src/common/schema.hpp
+++ b/src/common/schema.hpp
@@ -74,15 +74,15 @@ M create_message(T &&v) {
   M msg;
 
   msg["opcode"_f] = S.data;
-  msg.get<S>() = std::forward<T>(v);
+  msg.template get<S>() = std::forward<T>(v);
 
   return msg;
 }
 
 template <pp::basic_fixed_string S, typename M>
-M::template get_type_by_name<S>::base_type compare_message(const M &msg) {
+typename M::template get_type_by_name<S>::base_type compare_message(const M &msg) {
   if (msg["opcode"_f] == S.data) {
-    return msg.get_base<S>();
+    return msg.template get_base<S>();
   }
 
   return std::nullopt;

--- a/src/common/schema.hpp
+++ b/src/common/schema.hpp
@@ -62,7 +62,8 @@ using InjecteeMessage =
 
 using InjectorConfig =
     pp::message<pp::message_field<"addr", 1, IpAddr>, pp::bool_field<"log", 2>,
-                pp::bool_field<"subprocess", 3>>;
+                pp::bool_field<"subprocess", 3>, pp::uint32_field<"proxy_type", 4>,
+                pp::string_field<"username", 5>, pp::string_field<"password", 6>>;
 
 using InjectorMessage =
     pp::message<pp::string_field<"opcode", 1>,

--- a/src/common/winraii.hpp
+++ b/src/common/winraii.hpp
@@ -114,7 +114,7 @@ template <typename T> struct scope_ptr_bind {
 };
 
 template <typename F> void match_process(F &&f) {
-  if (handle snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, NULL)) {
+  if (handle snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)) {
     PROCESSENTRY32W entry = {sizeof(PROCESSENTRY32W)};
     if (Process32FirstW(snapshot.get(), &entry)) {
       do {

--- a/src/injectee/http_proxy.hpp
+++ b/src/injectee/http_proxy.hpp
@@ -1,0 +1,162 @@
+// Copyright 2022 PragmaTwice
+//
+// Licensed under the Apache License,
+// Version 2.0(the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PROXINJECT_INJECTEE_HTTP_PROXY
+#define PROXINJECT_INJECTEE_HTTP_PROXY
+
+#include <WinSock2.h>
+#include <WS2tcpip.h>
+#include <cstddef>
+#include <schema.hpp>
+#include <string>
+
+constexpr const char HTTP_CONNECT_SUCCESS = 0;
+constexpr const char HTTP_CONNECT_FAILURE = 1;
+
+inline std::string base64_encode(const std::string &input) {
+  static const char base64_chars[] =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+  std::string result;
+  result.reserve(((input.size() + 2) / 3) * 4);
+
+  size_t i = 0;
+  while (i + 2 < input.size()) {
+    unsigned char b0 = input[i++];
+    unsigned char b1 = input[i++];
+    unsigned char b2 = input[i++];
+
+    result.push_back(base64_chars[b0 >> 2]);
+    result.push_back(base64_chars[((b0 & 0x03) << 4) | (b1 >> 4)]);
+    result.push_back(base64_chars[((b1 & 0x0f) << 2) | (b2 >> 6)]);
+    result.push_back(base64_chars[b2 & 0x3f]);
+  }
+
+  if (i < input.size()) {
+    unsigned char b0 = input[i++];
+    result.push_back(base64_chars[b0 >> 2]);
+
+    if (i < input.size()) {
+      unsigned char b1 = input[i++];
+      result.push_back(base64_chars[((b0 & 0x03) << 4) | (b1 >> 4)]);
+      result.push_back(base64_chars[(b1 & 0x0f) << 2]);
+      result.push_back('=');
+    } else {
+      result.push_back(base64_chars[(b0 & 0x03) << 4]);
+      result.push_back('=');
+      result.push_back('=');
+    }
+  }
+
+  return result;
+}
+
+inline std::string format_host_port(const sockaddr *addr) {
+  char host[INET6_ADDRSTRLEN];
+  std::uint16_t port;
+
+  if (addr->sa_family == AF_INET) {
+    auto v4 = (const sockaddr_in *)addr;
+    inet_ntop(AF_INET, &v4->sin_addr, host, sizeof(host));
+    port = ntohs(v4->sin_port);
+  } else if (addr->sa_family == AF_INET6) {
+    auto v6 = (const sockaddr_in6 *)addr;
+    inet_ntop(AF_INET6, &v6->sin6_addr, host, sizeof(host));
+    port = ntohs(v6->sin6_port);
+  } else {
+    return "";
+  }
+
+  return std::string(host) + ":" + std::to_string(port);
+}
+
+inline std::string format_host_port(const IpAddr &addr) {
+  auto [host, port] = to_asio(addr);
+  return host + ":" + std::to_string(port);
+}
+
+char http_connect(SOCKET s, const std::string &host_port,
+                  const std::string &username, const std::string &password) {
+  std::string request = "CONNECT " + host_port + " HTTP/1.1\r\n";
+  request += "Host: " + host_port + "\r\n";
+
+  if (!username.empty()) {
+    std::string credentials = username + ":" + password;
+    request += "Proxy-Authorization: Basic " + base64_encode(credentials) + "\r\n";
+  }
+
+  request += "\r\n";
+
+  if (send(s, request.c_str(), (int)request.size(), 0) != (int)request.size())
+    return HTTP_CONNECT_FAILURE;
+
+  // Read response - look for HTTP/1.x 200
+  char response[1024];
+  int total_received = 0;
+  bool found_end = false;
+
+  while (total_received < sizeof(response) - 1 && !found_end) {
+    int received = recv(s, response + total_received, 1, 0);
+    if (received <= 0)
+      return HTTP_CONNECT_FAILURE;
+    total_received += received;
+
+    // Check for end of headers (\r\n\r\n)
+    if (total_received >= 4) {
+      if (response[total_received - 4] == '\r' &&
+          response[total_received - 3] == '\n' &&
+          response[total_received - 2] == '\r' &&
+          response[total_received - 1] == '\n') {
+        found_end = true;
+      }
+    }
+  }
+
+  response[total_received] = '\0';
+
+  // Check for success response (HTTP/1.x 200)
+  if (total_received < 12)
+    return HTTP_CONNECT_FAILURE;
+
+  if (strncmp(response, "HTTP/1.", 7) != 0)
+    return HTTP_CONNECT_FAILURE;
+
+  // Find status code after "HTTP/1.x "
+  const char *status_start = response + 9;
+  if (strncmp(status_start, "200", 3) != 0)
+    return HTTP_CONNECT_FAILURE;
+
+  return HTTP_CONNECT_SUCCESS;
+}
+
+char http_connect(SOCKET s, const sockaddr *addr, const std::string &username,
+                  const std::string &password) {
+  std::string host_port = format_host_port(addr);
+  if (host_port.empty())
+    return HTTP_CONNECT_FAILURE;
+
+  return http_connect(s, host_port, username, password);
+}
+
+char http_connect(SOCKET s, const IpAddr &addr, const std::string &username,
+                  const std::string &password) {
+  std::string host_port = format_host_port(addr);
+  if (host_port.empty())
+    return HTTP_CONNECT_FAILURE;
+
+  return http_connect(s, host_port, username, password);
+}
+
+#endif

--- a/src/injector/injector_cli.cpp
+++ b/src/injector/injector_cli.cpp
@@ -279,6 +279,7 @@ int main(int argc, char *argv[]) {
 
   // Watch mode: continuously monitor for new processes
   if (!watch_pattern.empty()) {
+    server.set_watch_mode(true);
     info("watch mode: monitoring for processes matching '{}'", watch_pattern);
     info("press Ctrl+C to stop");
 

--- a/src/injector/injector_cli.cpp
+++ b/src/injector/injector_cli.cpp
@@ -104,6 +104,18 @@ auto create_parser() {
       .default_value(false)
       .implicit_value(true);
 
+  parser.add_argument("-t", "--proxy-type")
+      .help("proxy type: socks5 (default) or http")
+      .default_value(string{"socks5"});
+
+  parser.add_argument("-U", "--proxy-user")
+      .help("proxy username for authentication")
+      .default_value(string{});
+
+  parser.add_argument("-W", "--proxy-pass")
+      .help("proxy password for authentication")
+      .default_value(string{});
+
   return parser;
 }
 
@@ -161,6 +173,24 @@ int main(int argc, char *argv[]) {
       server.set_proxy(ip::address::from_string(addr), port);
       info("proxy address set to {}:{}", addr, port);
     }
+  }
+
+  if (auto proxy_type = parser.get<string>("-t"); proxy_type == "http") {
+    server.set_proxy_type(1);
+    info("proxy type set to http");
+  } else {
+    server.set_proxy_type(0);
+    info("proxy type set to socks5");
+  }
+
+  if (auto username = parser.get<string>("-U"); !username.empty()) {
+    server.set_proxy_username(username);
+    info("proxy username set");
+  }
+
+  if (auto password = parser.get<string>("-W"); !password.empty()) {
+    server.set_proxy_password(password);
+    info("proxy password set");
   }
 
   bool has_process = false;

--- a/src/injector/injector_cli.hpp
+++ b/src/injector/injector_cli.hpp
@@ -21,6 +21,7 @@
 #include <spdlog/spdlog.h>
 
 using spdlog::info;
+using spdlog::error;
 
 struct injectee_session_cli : injectee_session {
   using injectee_session::injectee_session;

--- a/src/injector/injector_cli.hpp
+++ b/src/injector/injector_cli.hpp
@@ -42,7 +42,7 @@ struct injectee_session_cli : injectee_session {
 
   void process_close() override {
     info("{}: closed", (int)pid_);
-    if (server_.clients.size() == 0) {
+    if (server_.clients.size() == 0 && !server_.watch_mode_) {
       info("all processes have been exited, exit");
 
       exit(0);

--- a/src/injector/server.hpp
+++ b/src/injector/server.hpp
@@ -40,8 +40,10 @@ struct injector_server {
   std::mutex config_mutex;
 
   std::uint16_t port_ = -1;
+  bool watch_mode_ = false;
 
   void set_port(std::uint16_t port) { port_ = port; }
+  void set_watch_mode(bool enabled = true) { watch_mode_ = enabled; }
 
   bool inject(DWORD pid) {
     if (port_ == -1) {

--- a/src/injector/server.hpp
+++ b/src/injector/server.hpp
@@ -98,6 +98,27 @@ struct injector_server {
 
   void disable_subprocess() { enable_subprocess(false); }
 
+  void set_proxy_type(std::uint32_t type) {
+    std::lock_guard guard(config_mutex);
+    config_["proxy_type"_f] = type;
+
+    broadcast_config();
+  }
+
+  void set_proxy_username(const std::string &username) {
+    std::lock_guard guard(config_mutex);
+    config_["username"_f] = username;
+
+    broadcast_config();
+  }
+
+  void set_proxy_password(const std::string &password) {
+    std::lock_guard guard(config_mutex);
+    config_["password"_f] = password;
+
+    broadcast_config();
+  }
+
   InjectorConfig get_config() {
     std::lock_guard guard(config_mutex);
     return config_;


### PR DESCRIPTION
## Summary
- **HTTP proxy support**: Added HTTP CONNECT proxy support alongside SOCKS5
- **Proxy authentication**: Support username/password auth for both SOCKS5 and HTTP proxies
- **Watch mode** (`-w`): Automatically re-injects proxy when a monitored process restarts
- **Hostname/domain support**: Accept hostnames (e.g. `proxy.example.com`) in addition to IP addresses, with DNS resolution
- **Static linking**: Link CRT statically for portable single-binary deployment

## Changes
- `feat: add HTTP proxy support and proxy authentication`
- `feat: add watch mode, hostname support, and static linking`
- `fix: prevent exit in watch mode when process closes`